### PR TITLE
small image link typo

### DIFF
--- a/units/en/unit1/sdk.mdx
+++ b/units/en/unit1/sdk.mdx
@@ -143,7 +143,7 @@ You can then open the MCP Inspector at [http://127.0.0.1:6274](http://127.0.0.1:
 
 You'll see the server's capabilities and the ability to call them via the UI.
 
-![MCP Inspector]([./images/mcp-inspector.png](https://huggingface.co/datasets/mcp-course/images/resolve/main/unit1/6.png)
+![MCP Inspector](https://huggingface.co/datasets/mcp-course/images/resolve/main/unit1/6.png)
 
 ## MCP SDKs
 


### PR DESCRIPTION
Fixing a small typo that is blocking an image to be rendered on SDK page