### PR TITLE
Fix typos and grammar in Unit 0 introduction 

### DIFF
--- a/units/en/unit0/introduction.mdx
+++ b/units/en/unit0/introduction.mdx
@@ -81,7 +81,7 @@ The above courses are not prerequisites in themselves, so if you understand the 
 You only need 2 things:
 
 * _A computer_ with an internet connection.
-* An _Account_: to access the course resources and create projects. If you don't have an account yet, you can create one [here](https://huggingface.co/join) (it's free).
+* An _account_: to access the course resources and create projects. If you don't have an account yet, you can create one [here](https://huggingface.co/join) (it's free).
 
 ## The Certification Process
 
@@ -116,7 +116,7 @@ About the authors:
 
 ### Ben Burtenshaw
 
-Ben is a Machine Learning Engineer at Hugging Face who focuses building LLM applications, with post training and agentic approaches.
+Ben is a Machine Learning Engineer at Hugging Face who focuses on building LLM applications, with post training and agentic approaches.
 
 <!-- ## Acknowledgments -->
 
@@ -130,7 +130,7 @@ Contributions are **welcome** 🤗
 
 * If you _found a bug 🐛 in a notebook_, please open an issue and **describe the problem**.
 * If you _want to improve the course_, you can open a Pull Request.
-* If you _want to add a full section or a new unit_, the best is to open an issue and **describe what content you want to add before starting to write it so that we can guide you**.
+* If you _want to add a full section or a new unit_, it is best to open an issue and **describe what content you want to add before starting to write it so that we can guide you**.
 
 ## I still have questions
 


### PR DESCRIPTION
This pull request addresses minor typos and grammatical errors found in the introduction to Unit 0 (`units/en/unit0/introduction.mdx`).

Changes include:
- Lowercased 'Account' to 'account'.
- Added 'on' to 'focuses building' to make 'focuses on building'.
- Rephrased 'the best is' to 'it is best' for better flow.
