### PR TITLE
Added MCP Dart SDK

### DIFF
--- a/units/en/unit1/sdk.mdx
+++ b/units/en/unit1/sdk.mdx
@@ -158,6 +158,7 @@ MCP is designed to be language-agnostic, and there are official SDKs available f
 | C# | [github.com/modelcontextprotocol/csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk) | Microsoft | Active (Preview) |
 | Swift | [github.com/modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk) | loopwork-ai | Active |
 | Rust | [github.com/modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) | Anthropic/Community | Active |
+| Dart | [https://github.com/leehack/mcp_dart](https://github.com/leehack/mcp_dart) | Flutter Community | Active |
 
 These SDKs provide language-specific abstractions that simplify working with the MCP protocol, allowing you to focus on implementing the core logic of your servers or clients rather than dealing with low-level protocol details.
 


### PR DESCRIPTION
I’ve added the MCP Dart SDK, which is maintained by the Flutter Community.