### PR TITLE
Fixed grammar in multiple files

### DIFF
--- a/units/en/unit1/key-concepts.mdx
+++ b/units/en/unit1/key-concepts.mdx
@@ -78,7 +78,7 @@ In the following diagram, we can see the collective capabilities applied to a us
 
 ![collective diagram](https://huggingface.co/datasets/mcp-course/images/resolve/main/unit1/8.png)
 
-This application might use the MCP entities in the following way:
+This application might use their MCP entities in the following way:
 
 | Entity | Name | Description |
 | --- | --- | --- |

--- a/units/en/unit1/key-concepts.mdx
+++ b/units/en/unit1/key-concepts.mdx
@@ -78,7 +78,7 @@ In the following diagram, we can see the collective capabilities applied to a us
 
 ![collective diagram](https://huggingface.co/datasets/mcp-course/images/resolve/main/unit1/8.png)
 
-This application might use their MCP entities in the following way:
+This application might use the MCP entities in the following way:
 
 | Entity | Name | Description |
 | --- | --- | --- |

--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -304,7 +304,7 @@ The weather in Tokyo is sunny with a temperature of 20 degrees Celsius.
 
 </details>
 
-We can also connect to an MCP packages. Here's an example of connecting to the `pubmedmcp` package.
+We can also connect to an MCP package. Here's an example of connecting to the `pubmedmcp` package.
 
 ```python
 from smolagents import ToolCollection, CodeAgent


### PR DESCRIPTION
This pull request improves the documentation by replacing the unclear pronoun **"their"** with **"the MCP entities,"** making the sentence clearer since MCP is a protocol, not a person or group.

**Updated text:**

> *This application might use the MCP entities in the following way:*

Also fixed a grammar issue in `mcp-clients.mdx`:

**Before:**

> *We can also connect to an MCP packages.*

**After:**

> *We can also connect to an MCP package.*