### PR TITLE
fix: removed unused import from code clients example snippet

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -224,7 +224,7 @@ You can also use the MCP Client in within code so that the tools are available t
 First, let's explore our weather server from the previous page. In `smolagents`, we can use the `ToolCollection` class to automatically discover and register tools from an MCP server. This is done by passing the `StdioServerParameters` or `SSEServerParameters` to the `ToolCollection.from_mcp` method. We can then print the tools to the console.
 
 ```python
-from smolagents import ToolCollection, CodeAgent
+from smolagents import ToolCollection
 from mcp.client.stdio import StdioServerParameters
 
 server_parameters = StdioServerParameters(command="uv", args=["run", "server.py"])


### PR DESCRIPTION
The import `CodeAgent` isn't used in the first snippet in the "Code Clients" section.