### PR TITLE
fix: updated output for tool discovery from server.py

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -242,7 +242,7 @@ Output
 </summary>
 
 ```sh
-Weather API: Get the weather in a specific location
+get_weather: Get the current weather for a specified location.
 
 ```
 


### PR DESCRIPTION
- The tool name as mentioned in _server.py_ is `"get_weather"` instead of the current `"Weather API"`
- The tool description as mentioned in _server.py_ is `"Get the current weather for a specified location."` instead of the current `"Get the weather in a specific location"`.