### PR TITLE
fix: added missing os import

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -306,6 +306,7 @@ The weather in Tokyo is sunny with a temperature of 20 degrees Celsius.
 We can also connect to an MCP package. Here's an example of connecting to the `pubmedmcp` package.
 
 ```python
+import os
 from smolagents import ToolCollection, CodeAgent
 from mcp import StdioServerParameters
 


### PR DESCRIPTION
- Needed for `os.environ`