### PR TITLE
Update gradio-client.mdx

### DIFF
--- a/units/en/unit2/gradio-client.mdx
+++ b/units/en/unit2/gradio-client.mdx
@@ -81,7 +81,7 @@ from mcp.client.stdio import StdioServerParameters
 from smolagents import InferenceClientModel, CodeAgent, ToolCollection
 from smolagents.mcp_client import MCPClient
 
-
+mcp_client = None
 try:
     mcp_client = MCPClient(
         ## Try this working example on the hub:


### PR DESCRIPTION
Initializing the mcp_client outside of the try block to ensure it's in scope for the finally block.