### PR TITLE
Update tiny-agents.mdx

### DIFF
--- a/units/en/unit2/tiny-agents.mdx
+++ b/units/en/unit2/tiny-agents.mdx
@@ -20,9 +20,9 @@ pnpm add @huggingface/tiny-agents
 Then, we need to install the `mcp-remote` package.
 
 ```bash
-npm install @mcpjs/mcp-remote
+npm i mcp-remote
 # or
-pnpm add @mcpjs/mcp-remote
+pnpm add mcp-remote
 ```
 
 ## Tiny Agents MCP Client in the Command Line


### PR DESCRIPTION
Updating the mcp-remote npm scripts.

Fixes the following errors:
@mcpjs/mcp-remote is not in the npm registry, or you have no permission to fetch it. Not Found - GET https://registry.npmjs.org/@mcpjs%2fmcp-remote - Not found