### PR TITLE
Update mcp-clients.mdx pubmedmcp example

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -219,7 +219,7 @@ In the next section, we'll explore the ecosystem of MCP servers available on Hug
 
 ## Code Clients
 
-You can also use the MCP Client in within code so that the tools are available to the LLM. Let's explore some examples in `smolagents`.
+You can also use the MCP Client in within code so that the tools are available to the LLM. Let's explore some examples in `smolagents`.  To run these examples you will need to add `mcp[cli]`, `smolagents[toolkit]`, and `smolagents[mcp]` to your `uv` virtual environment.
 
 First, let's explore our weather server from the previous page. In `smolagents`, we can use the `ToolCollection` class to automatically discover and register tools from an MCP server. This is done by passing the `StdioServerParameters` or `SSEServerParameters` to the `ToolCollection.from_mcp` method. We can then print the tools to the console.
 
@@ -307,17 +307,19 @@ We can also connect to an MCP package. Here's an example of connecting to the `p
 
 ```python
 import os
-from smolagents import ToolCollection, CodeAgent
-from mcp import StdioServerParameters
+from smolagents import ToolCollection, CodeAgent, InferenceClientModel
+from mcp.client.stdio import StdioServerParameters
+
+model = InferenceClientModel()
 
 server_parameters = StdioServerParameters(
-    command="uv",
+    command="uvx",
     args=["--quiet", "pubmedmcp@0.1.3"],
     env={"UV_PYTHON": "3.12", **os.environ},
 )
 
 with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
-    agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
+    agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True, model=model)
     agent.run("Please find a remedy for hangover.")
 ```
 


### PR DESCRIPTION
Updates to `pubmedmcp` example for easier setup and usage, including:

- explicitly mention required installs (`mcp[cli]`, `smolagents[toolkit]`, and `smolagents[mcp]`)
- use `uv` instead of `uvx` to remove the need to manually install `pubmedclient` in order to use `pubmedmcp@0.1.3` and better isolating the tool usage
- pass [required arg `model`](https://github.com/huggingface/smolagents/blob/6a12ebdf210207eec22d5940157f522463fc1c59/src/smolagents/agents.py#L1345) to `CodeAgent` init to prevent `TypeError: CodeAgent.__init__() missing 1 required positional argument: 'model'`with current implementation
- import and add init for `model = InferenceClientModel()` to pass to `CodeAgent`