### PR TITLE
Unit 1 update gradio mcp client endpoint to work around mcp 1.9.0 breaking change

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -254,7 +254,7 @@ We can also connect to an MCP server that is hosted on a remote machine. In this
 from smolagents.mcp_client import MCPClient
 
 with MCPClient(
-    {"url": "https://abidlabs-mcp-tools.hf.space/gradio_api/mcp/sse"}
+    {"url": "https://abidlabs-mcp-tools2.hf.space/gradio_api/mcp/sse"}
 ) as tools:
     # Tools from the remote server are available
     print("\n".join(f"{t.name}: {t.description}" for t in tools))

--- a/units/vi/unit1/mcp-clients.mdx
+++ b/units/vi/unit1/mcp-clients.mdx
@@ -302,7 +302,7 @@ Chúng ta cũng có thể kết nối đến Server MCP được host trên máy
 from smolagents.mcp_client import MCPClient
 
 with MCPClient(
-    {"url": "https://abidlabs-mcp-tools.hf.space/gradio_api/mcp/sse"}
+    {"url": "https://abidlabs-mcp-tools2.hf.space/gradio_api/mcp/sse"}
 ) as tools:
     # Tools from the remote server are available
     print("\n".join(f"{t.name}: {t.description}" for t in tools))
@@ -312,7 +312,7 @@ with MCPClient(
 from smolagents.mcp_client import MCPClient
 
 with MCPClient(
-    {"url": "https://abidlabs-mcp-tools.hf.space/gradio_api/mcp/sse"}
+    {"url": "https://abidlabs-mcp-tools2.hf.space/gradio_api/mcp/sse"}
 ) as tools:
     # Tools from the remote server are available
     print("\n".join(f"{t.name}: {t.description}" for t in tools))


### PR DESCRIPTION
`mcp` 1.9.0 has a [breaking change for gradio mcp endpoints currently under investigation](https://github.com/gradio-app/gradio/issues/11225#issuecomment-2893381049).

The example gradio endpoint in unit 1 `https://abidlabs-mcp-tools.hf.space/gradio_api/mcp/sse` uses this latest version and returns `404` errors at present when invoked via the example code.

This PR replaces the endpoint with a duplicated space created by the same author `https://abidlabs-mcp-tools2.hf.space/gradio_api/mcp/sse` that pins `mcp` to `1.8.1`, avoiding the breaking change allowing the example to function as expected.

This is a temporary solution but at least prevents `404` returns from the current endpoint.  It likewise addresses #57.