### PR TITLE
Update clients.mdx (local/remote confusion)

### DIFF
--- a/units/en/unit2/clients.mdx
+++ b/units/en/unit2/clients.mdx
@@ -20,9 +20,9 @@ The standard configuration file for MCP is named `mcp.json`. Here's the basic st
 {
   "servers": [
     {
-      "name": "MCP Server",
+      "name": "Local MCP Server",
       "transport": {
-        "type": "sse",
+        "type": "stdio",
         "url": "http://localhost:7860/gradio_api/mcp/sse"
       }
     }
@@ -30,11 +30,11 @@ The standard configuration file for MCP is named `mcp.json`. Here's the basic st
 }
 ```
 
-In this example, we have a single server configured to use SSE transport, connecting to a local Gradio server running on port 7860.
+In this example, we have a single server configured to use Standard Input/Output transport, connecting to a local Gradio server running on port 7860.
 
 <Tip>
 
-We've connected to the Gradio app via SSE transport because we assume that the gradio app is running on a remote server. However, if you want to connect to a local script, `stdio` transport instead of `sse` transport is a better option.
+We've connected to the Gradio app via Standard Input/Output transport because it is a better option than `sse` to connect to scripts locally. However, if you want to connect to a remote script, `sse` transport instead of `stdio` transport should be used.
 
 </Tip>
 


### PR DESCRIPTION
Edited transport type to `stdio` from `sse`, where the script was trying to connect to a local server