### PR TITLE
docs: improve SDK documentation structure and fix JavaScript server startup commands

### DIFF
--- a/units/en/unit1/sdk.mdx
+++ b/units/en/unit1/sdk.mdx
@@ -50,12 +50,19 @@ def weather_report(location: str) -> str:
 if __name__ == "__main__":
     mcp.run()
 
+Once you have your server implemented, you can start it by running the server script.
+
+```bash
+mcp dev server.py
+```
+
 ```
 
 </hfoption>
 <hfoption id="javascript">
 
 ```javascript
+// index.mjs
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -118,14 +125,14 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
 
-</hfoption>
-</hfoptions>
-
 Once you have your server implemented, you can start it by running the server script.
 
 ```bash
-mcp dev server.py
+npx @modelcontextprotocol/inspector node ./index.mjs
 ```
+
+</hfoption>
+</hfoptions>
 
 This will initialize a development server running the file `server.py`. And log the following output:
 

--- a/units/vi/unit1/sdk.mdx
+++ b/units/vi/unit1/sdk.mdx
@@ -152,9 +152,17 @@ server.prompt(
 const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
+
+Sau khi đã triển khai máy chủ của mình, bạn có thể khởi chạy nó bằng cách chạy script server.
+
+```bash
+mcp dev server.py
+```
+
 </details>
 
 ```javascript
+// index.mjs
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -217,14 +225,14 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
 
-</hfoption>
-</hfoptions>
-
 Sau khi đã triển khai máy chủ của mình, bạn có thể khởi chạy nó bằng cách chạy script server.
 
 ```bash
-mcp dev server.py
+npx @modelcontextprotocol/inspector node ./index.mjs
 ```
+
+</hfoption>
+</hfoptions>
 
 Lệnh này sẽ khởi tạo một máy chủ phát triển chạy file `server.py` và ghi lại output sau:
 


### PR DESCRIPTION
- Add filename comments to JavaScript code blocks for better clarity
- Reorganize code examples to improve readability and flow
- Fix JavaScript server startup command from 'mcp dev server.py' to 'npx @modelcontextprotocol/inspector node ./index.mjs'
- Ensure consistency between English and Vietnamese documentation versions