### PR TITLE
 Fix indefinite article: “a MCP server” → “an MCP server”

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -281,7 +281,7 @@ Now, let's create an agent configuration file `agent.json`.
 }
 ```
 
-In this configuration, we are using the `@playwright/mcp` MCP server. This is a MCP server that can control a browser with Playwright.
+In this configuration, we are using the `@playwright/mcp` MCP server. This is an MCP server that can control a browser with Playwright.
 
 Now you can run the agent:
 

--- a/units/en/unit2/clients.mdx
+++ b/units/en/unit2/clients.mdx
@@ -78,7 +78,7 @@ Create a new file called `config.json` with the following configuration:
 
 This configuration allows your UI client to communicate with the Gradio MCP server using the MCP protocol, enabling seamless integration between your frontend and the MCP service.
 
-## Configuring a MCP Client within Cursor IDE
+## Configuring an MCP Client within Cursor IDE
 
 Cursor provides built-in MCP support, allowing you to connect your deployed MCP servers directly to your development environment.
 


### PR DESCRIPTION
**Fix**: `a MCP server` → `an MCP server`  
Because **M** is pronounced “em,” it starts with a vowel sound, so the correct article is **an**.  
Ref: *Chicago Manual of Style* Q&A — “the choice of **a/an** is determined by how the abbreviation is read aloud.”  
<https://www.chicagomanualofstyle.org/qanda/data/faq/topics/Abbreviations/faq0010.html>
