### PR TITLE
docs: add screencasts demonstrating MCP server functionality in Unit 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ cython_debug/
 .pypirc
 
 .DS_Store
+
+videos/

--- a/projects/unit3/slack-notification/solution/server.py
+++ b/projects/unit3/slack-notification/solution/server.py
@@ -272,15 +272,19 @@ async def send_slack_notification(message: str) -> str:
     
     Args:
         message: The message to send to Slack (supports Slack markdown)
+        
+    IMPORTANT: For CI failures, use format_ci_failure_alert prompt first!
+    IMPORTANT: For deployments, use format_ci_success_summary prompt first!
     """
     webhook_url = os.getenv("SLACK_WEBHOOK_URL")
     if not webhook_url:
         return "Error: SLACK_WEBHOOK_URL environment variable not set"
     
     try:
-        # Prepare the payload
+        # Prepare the payload with proper Slack formatting
         payload = {
-            "text": message
+            "text": message,
+            "mrkdwn": True
         }
         
         # Send POST request to Slack webhook
@@ -311,17 +315,15 @@ async def format_ci_failure_alert():
     """Create a Slack alert for CI/CD failures with rich formatting."""
     return """Format this GitHub Actions failure as a Slack message using ONLY Slack markdown syntax:
 
-❌ *CI Failed* - [Repository Name]
+:rotating_light: *CI Failure Alert* :rotating_light:
 
-> Brief summary of what failed
+A CI workflow has failed:
+*Workflow*: workflow_name
+*Branch*: branch_name
+*Status*: Failed
+*View Details*: <https://github.com/test/repo/actions/runs/123|View Logs>
 
-*Details:*
-• Workflow: `workflow_name`
-• Branch: `branch_name`  
-• Commit: `commit_hash`
-
-*Next Steps:*
-• <https://github.com/test/repo/actions/runs/123|View Action Logs>
+Please check the logs and address any issues.
 
 CRITICAL: Use EXACT Slack link format: <https://full-url|Link Text>
 Examples:
@@ -329,11 +331,12 @@ Examples:
 - WRONG: [Repository](https://github.com/user/repo)
 - WRONG: https://github.com/user/repo
 
-Other Slack formats:
+Slack formatting rules:
 - *text* for bold (NOT **text**)
 - `text` for code
 - > text for quotes
-- • for bullets"""
+- Use simple bullet format without special characters
+- :emoji_name: for emojis"""
 
 
 @mcp.prompt()
@@ -341,16 +344,16 @@ async def format_ci_success_summary():
     """Create a Slack message celebrating successful deployments."""
     return """Format this successful GitHub Actions run as a Slack message using ONLY Slack markdown syntax:
 
-✅ *Deployment Successful* - [Repository Name]
+:white_check_mark: *Deployment Successful* :white_check_mark:
 
-> Brief summary of what was deployed
+Deployment completed successfully for [Repository Name]
 
 *Changes:*
-• Key feature or fix 1
-• Key feature or fix 2
+- Key feature or fix 1
+- Key feature or fix 2
 
 *Links:*
-• <https://github.com/user/repo|View Changes>
+<https://github.com/user/repo|View Changes>
 
 CRITICAL: Use EXACT Slack link format: <https://full-url|Link Text>
 Examples:
@@ -358,11 +361,12 @@ Examples:
 - WRONG: [Repository](https://github.com/user/repo)
 - WRONG: https://github.com/user/repo
 
-Other Slack formats:
+Slack formatting rules:
 - *text* for bold (NOT **text**)
 - `text` for code
 - > text for quotes
-- • for bullets"""
+- Use simple bullet format with - or *
+- :emoji_name: for emojis"""
 
 
 # ===== Prompts from Module 2 (Complete) =====
@@ -379,11 +383,11 @@ async def analyze_ci_results():
 
 Format your response as:
 ## CI/CD Status Summary
-- **Overall Health**: [Good/Warning/Critical]
-- **Failed Workflows**: [List any failures with links]
-- **Successful Workflows**: [List recent successes]
-- **Recommendations**: [Specific actions to take]
-- **Trends**: [Any patterns you notice]"""
+- *Overall Health*: [Good/Warning/Critical]
+- *Failed Workflows*: [List any failures with links]
+- *Successful Workflows*: [List recent successes]
+- *Recommendations*: [Specific actions to take]
+- *Trends*: [Any patterns you notice]"""
 
 
 @mcp.prompt()
@@ -397,14 +401,14 @@ async def create_deployment_summary():
 
 Format as a concise message suitable for Slack:
 
-🚀 **Deployment Update**
-- **Status**: [✅ Success / ❌ Failed / ⏳ In Progress]
-- **Environment**: [Production/Staging/Dev]
-- **Version/Commit**: [If available from workflow data]
-- **Duration**: [If available]
-- **Key Changes**: [Brief summary if available]
-- **Issues**: [Any problems encountered]
-- **Next Steps**: [Required actions if failed]
+🚀 *Deployment Update*
+- *Status*: [✅ Success / ❌ Failed / ⏳ In Progress]
+- *Environment*: [Production/Staging/Dev]
+- *Version/Commit*: [If available from workflow data]
+- *Duration*: [If available]
+- *Key Changes*: [Brief summary if available]
+- *Issues*: [Any problems encountered]
+- *Next Steps*: [Required actions if failed]
 
 Keep it brief but informative for team awareness."""
 
@@ -424,21 +428,21 @@ Create a detailed report with:
 ## 📋 PR Status Report
 
 ### 📝 Code Changes
-- **Files Modified**: [Count by type - .py, .js, etc.]
-- **Change Type**: [Feature/Bug/Refactor/etc.]
-- **Impact Assessment**: [High/Medium/Low with reasoning]
-- **Key Changes**: [Bullet points of main modifications]
+- *Files Modified*: [Count by type - .py, .js, etc.]
+- *Change Type*: [Feature/Bug/Refactor/etc.]
+- *Impact Assessment*: [High/Medium/Low with reasoning]
+- *Key Changes*: [Bullet points of main modifications]
 
 ### 🔄 CI/CD Status
-- **All Checks**: [✅ Passing / ❌ Failing / ⏳ Running]
-- **Test Results**: [Pass rate, failed tests if any]
-- **Build Status**: [Success/Failed with details]
-- **Code Quality**: [Linting, coverage if available]
+- *All Checks*: [✅ Passing / ❌ Failing / ⏳ Running]
+- *Test Results*: [Pass rate, failed tests if any]
+- *Build Status*: [Success/Failed with details]
+- *Code Quality*: [Linting, coverage if available]
 
 ### 📌 Recommendations
-- **PR Template**: [Suggested template and why]
-- **Next Steps**: [What needs to happen before merge]
-- **Reviewers**: [Suggested reviewers based on files changed]
+- *PR Template*: [Suggested template and why]
+- *Next Steps*: [What needs to happen before merge]
+- *Reviewers*: [Suggested reviewers based on files changed]
 
 ### ⚠️ Risks & Considerations
 - [Any deployment risks]
@@ -461,20 +465,20 @@ Structure your response as:
 ## 🔧 Workflow Troubleshooting Guide
 
 ### ❌ Failed Workflow Details
-- **Workflow Name**: [Name of failing workflow]
-- **Failure Type**: [Test/Build/Deploy/Lint]
-- **First Failed**: [When did it start failing]
-- **Failure Rate**: [Intermittent or consistent]
+- *Workflow Name*: [Name of failing workflow]
+- *Failure Type*: [Test/Build/Deploy/Lint]
+- *First Failed*: [When did it start failing]
+- *Failure Rate*: [Intermittent or consistent]
 
 ### 🔍 Diagnostic Information
-- **Error Patterns**: [Common error messages or symptoms]
-- **Recent Changes**: [What changed before failures started]
-- **Dependencies**: [External services or resources involved]
+- *Error Patterns*: [Common error messages or symptoms]
+- *Recent Changes*: [What changed before failures started]
+- *Dependencies*: [External services or resources involved]
 
 ### 💡 Possible Causes (ordered by likelihood)
-1. **[Most Likely]**: [Description and why]
-2. **[Likely]**: [Description and why]
-3. **[Possible]**: [Description and why]
+1. *[Most Likely]*: [Description and why]
+2. *[Likely]*: [Description and why]
+3. *[Possible]*: [Description and why]
 
 ### ✅ Suggested Fixes
 **Immediate Actions:**

--- a/units/en/unit3/build-mcp-server.mdx
+++ b/units/en/unit3/build-mcp-server.mdx
@@ -15,9 +15,48 @@ The team knows they need better PR descriptions, but everyone's too busy shippin
 
 **Your mission**: Build an intelligent PR Agent that analyzes code changes and suggests helpful descriptions automatically.
 
+### Screencast: The PR Problem in Action 😬
+
+<video controls>
+  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/pr-chaos-at-cc-studios-small.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
+**What You'll See**: A real PR at CodeCraft Studios titled "various improvements" and the description simply says "Fixed some stuff and made updates". Classic, right?
+
+**The Confusion**: Watch as teammates struggle:
+- **Sarah** (3 hours ago): "What was fixed? I see changes to the User model but can't tell if this is addressing a bug or adding features"
+- **Jamie** (3 hours ago): "There are 8 files across 4 services... are these changes related? What should I focus on during review?"
+
+**The Pain Point**: The screencast shows the actual diff—8 files scattered across multiple services with zero context. Reviewers have to piece together the story themselves, wasting precious time and possibly missing critical issues.
+
+**Why This Matters**: This is exactly the PR chaos your MCP server will solve! By the end of this module, you'll turn these cryptic PRs into clear, actionable descriptions that make everyone's life easier.
+
 ## What You'll Build
 
 In this first module, you'll create the foundation of CodeCraft Studios' automation system: an MCP server that transforms how the team writes pull requests. This module focuses on core MCP concepts that you'll build upon in Modules 2 and 3.
+
+### Screencast: Your PR Agent Saves the Day! 🚀
+
+<video controls>
+  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/better-prs-at-cc-studios.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
+**The Solution in Action**: Watch how your MCP server will transform PR chaos into clarity:
+1. **`analyze_file_changes`** - Grabs all the changes (453 lines across 8 files!)
+2. **`get_pr_templates`** - Shows Claude the 7 templates to choose from
+3. **`suggest_template`** - Claude picks "Feature" (smart choice!)
+
+**What You'll See**: Claude doesn't just pick a template—it:
+- Writes a clear summary of what actually changed
+- Spots security issues (yikes, unhashed passwords!)
+- Creates a nice to-do list for follow-up work
+- Even prioritizes what needs fixing first
+
+**The "Wow" Moment** ✨: In just seconds, your MCP server helps Claude transform the same branch into a PR that actually explains what's going on. No more confused reviewers, no more "what does this do?" comments.
+
+**This is what you'll build**: A tool that turns PR dread into PR delight—let's get started!
 
 ## What You Will Learn
 

--- a/units/en/unit3/build-mcp-server.mdx
+++ b/units/en/unit3/build-mcp-server.mdx
@@ -17,10 +17,7 @@ The team knows they need better PR descriptions, but everyone's too busy shippin
 
 ### Screencast: The PR Problem in Action 😬
 
-<video controls>
-  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/pr-chaos-at-cc-studios-small.mp4" type="video/mp4" />
-  Your browser does not support the video tag.
-</video>
+<Youtube id="tskAUPWFPP0" />
 
 **What You'll See**: A real PR at CodeCraft Studios titled "various improvements" and the description simply says "Fixed some stuff and made updates". Classic, right?
 
@@ -38,10 +35,7 @@ In this first module, you'll create the foundation of CodeCraft Studios' automat
 
 ### Screencast: Your PR Agent Saves the Day! 🚀
 
-<video controls>
-  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/better-prs-at-cc-studios.mp4" type="video/mp4" />
-  Your browser does not support the video tag.
-</video>
+<Youtube id="OaAWJLvnlqc" />
 
 **The Solution in Action**: Watch how your MCP server will transform PR chaos into clarity:
 1. **`analyze_file_changes`** - Grabs all the changes (453 lines across 8 files!)

--- a/units/en/unit3/github-actions-integration.mdx
+++ b/units/en/unit3/github-actions-integration.mdx
@@ -18,13 +18,32 @@ The team realizes they need real-time visibility into their CI/CD pipeline, but 
 
 This module bridges the gap between static file analysis (Module 1) and dynamic team notifications (Module 3). You'll add real-time capabilities that transform your PR Agent into a comprehensive development monitoring system.
 
-## What You'll Build
-
 Building on the foundation you created in Module 1, you'll add:
 - **Webhook server** to receive GitHub Actions events
 - **New tools** for monitoring CI/CD status
 - **MCP Prompts** that provide consistent workflow patterns
 - **Real-time integration** with your GitHub repository
+
+### Screencast: Real-Time CI/CD Monitoring in Action! 🎯
+
+<video controls>
+  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/github-actions-integration-compressed.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
+**The Setup**: Watch how CodeCraft Studios' new system catches failures before they reach production:
+1. **GitHub Webhooks** - See the actual webhook configuration that sends events to your server
+2. **Failed Tests** - Those red X's that used to go unnoticed? Not anymore!
+3. **Local Development** - The webhook server and Cloudflare tunnel working together
+
+**MCP Magic in Real-Time**: Claude responds to three key requests:
+- **"What GitHub Actions events have we received?"** - Claude uses your new tools to check recent activity
+- **"Analyze CI Results"** - Watch Claude dig into test failures and provide actionable insights
+- **"Create Deployment Summary"** - See how MCP Prompts guide Claude to create team-friendly updates
+
+**The Silent Failures No More** 🚨: Remember that critical bug from Tuesday's failed test? With this system, Claude would have caught it immediately. The screencast shows exactly how your MCP server turns GitHub's raw webhook data into clear, actionable alerts.
+
+**What Makes This Special**: Your Module 1 PR Agent was static—it analyzed code when asked. This Module 2 enhancement is dynamic—it watches your CI/CD pipeline 24/7 and helps Claude provide real-time insights. No more Friday afternoon surprises!
 
 ## Learning Objectives
 

--- a/units/en/unit3/github-actions-integration.mdx
+++ b/units/en/unit3/github-actions-integration.mdx
@@ -26,10 +26,7 @@ Building on the foundation you created in Module 1, you'll add:
 
 ### Screencast: Real-Time CI/CD Monitoring in Action! 🎯
 
-<video controls>
-  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/github-actions-integration-compressed.mp4" type="video/mp4" />
-  Your browser does not support the video tag.
-</video>
+<Youtube id="XIEnmCicFXk" />
 
 **The Setup**: Watch how CodeCraft Studios' new system catches failures before they reach production:
 1. **GitHub Webhooks** - See the actual webhook configuration that sends events to your server

--- a/units/en/unit3/slack-notification.mdx
+++ b/units/en/unit3/slack-notification.mdx
@@ -29,10 +29,7 @@ Building on the foundation from Modules 1 and 2, you'll add the final piece of t
 
 ### Screencast: The Complete Automation System! 🎉
 
-<video controls>
-  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/slack-notification-compressed.mp4" type="video/mp4" />
-  Your browser does not support the video tag.
-</video>
+<Youtube id="sX5qrbDG-oY" />
 
 **The Final Piece**: Watch how your complete automation system prevents those Monday morning surprises that plagued Emma and Jake!
 

--- a/units/en/unit3/slack-notification.mdx
+++ b/units/en/unit3/slack-notification.mdx
@@ -22,12 +22,34 @@ The team realizes they have an information silo problem. Everyone's working hard
 
 This final module completes the CodeCraft Studios transformation. You'll integrate Tools and Prompts to create a smart notification system that sends formatted Slack messages about CI/CD events, demonstrating how all MCP primitives work together in a real-world scenario.
 
-## What You'll Build
-
 Building on the foundation from Modules 1 and 2, you'll add the final piece of the puzzle:
 - **Slack webhook tool** for sending messages to your team channel
 - **Two notification prompts** that intelligently format CI events
 - **Complete integration** showing all MCP primitives working together
+
+### Screencast: The Complete Automation System! 🎉
+
+<video controls>
+  <source src="https://huggingface.co/datasets/mcp-course/videos/resolve/main/unit3/slack-notification-compressed.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
+**The Final Piece**: Watch how your complete automation system prevents those Monday morning surprises that plagued Emma and Jake!
+
+**What You'll See**: 
+- **Claude's intelligent workflow** - Notice how Claude breaks down the task: ☐ Check events → ☐ Send notification
+- **Real-time MCP tools in action** - `get_recent_actions_events` pulls fresh CI data, then `send_slack_notification` delivers the alert
+- **Side-by-side demonstration** - The Slack channel is open in parallel to show the formatted message appearing as Claude sends it
+
+**The Smart Notification**: Claude doesn't just spam the team—it crafts a professional alert with:
+- 🚨 Clear urgency indicators and emoji
+- **Detailed failure breakdown** (test-auth-service ❌, test-api ❌, test-frontend ⏳)
+- **Actionable links** to the pipeline run and pull request
+- **Context everyone needs** - repository, PR #1 "various improvements", commit hash
+
+**Why This Matters**: Remember the communication gap crisis? No more! This system ensures that when CI fails on `demo-bad-pr` branch, the whole team knows immediately. No more weekend debugging sessions for issues that were already fixed!
+
+**The Complete Journey**: From Module 1's PR chaos to Module 3's intelligent team notifications—you've built a system that transforms how CodeCraft Studios collaborates. The weekend warriors become informed teammates! 🚀
 
 ## Learning Objectives
 
@@ -146,7 +168,7 @@ def send_slack_notification(message: str) -> str:
     
     try:
         # TODO: Send POST request to webhook_url
-        # TODO: Include message in JSON payload
+        # TODO: Include message in JSON payload with "mrkdwn": true
         # TODO: Handle response and return status
         pass
     except Exception as e:
@@ -167,18 +189,15 @@ Implement two prompts that generate Slack-formatted messages:
        return """Format this GitHub Actions failure as a Slack message:
 
    Use this template:
-   ❌ *CI Failed* - [Repository Name]
+   :rotating_light: *CI Failure Alert* :rotating_light:
    
-   > Brief summary of what failed
+   A CI workflow has failed:
+   *Workflow*: workflow_name
+   *Branch*: branch_name
+   *Status*: Failed
+   *View Details*: <LOGS_LINK|View Logs>
    
-   *Details:*
-   • Workflow: `workflow_name`
-   • Branch: `branch_name`
-   • Commit: `commit_hash`
-   
-   *Next Steps:*
-   • <PR_LINK|View Pull Request>
-   • <LOGS_LINK|Check Action Logs>
+   Please check the logs and address any issues.
    
    Use Slack markdown formatting and keep it concise for quick team scanning."""
    ```
@@ -191,17 +210,16 @@ Implement two prompts that generate Slack-formatted messages:
        return """Format this successful GitHub Actions run as a Slack message:
 
    Use this template:
-   ✅ *Deployment Successful* - [Repository Name]
+   :white_check_mark: *Deployment Successful* :white_check_mark:
    
-   > Brief summary of what was deployed
+   Deployment completed successfully for [Repository Name]
    
    *Changes:*
-   • Key feature or fix 1
-   • Key feature or fix 2
+   - Key feature or fix 1
+   - Key feature or fix 2
    
    *Links:*
-   • <PR_LINK|View Changes>
-   • <DEPLOY_LINK|Visit Site>
+   <PR_LINK|View Changes>
    
    Keep it celebratory but informative. Use Slack markdown formatting."""
    ```
@@ -265,33 +283,29 @@ Claude:
 
 **Failure Alert:**
 ```
-❌ *CI Failed* - mcp-course
+🚨 *CI Failure Alert* 🚨
 
-> Tests failed in Module 3 implementation
+A CI workflow has failed:
+*Workflow*: CI (Run #42)
+*Branch*: feature/slack-integration
+*Status*: Failed
+*View Details*: <https://github.com/user/mcp-course/actions/runs/123|View Logs>
 
-*Details:*
-• Workflow: `CI`
-• Branch: `feature/slack-integration`
-• Commit: `abc123f`
-
-*Next Steps:*
-• <https://github.com/user/mcp-course/pull/42|View Pull Request>
-• <https://github.com/user/mcp-course/actions/runs/123|Check Action Logs>
+Please check the logs and address any issues.
 ```
 
 **Success Summary:**
 ```
-✅ *Deployment Successful* - mcp-course
+✅ *Deployment Successful* ✅
 
-> Module 3 Slack integration deployed to staging
+Deployment completed successfully for mcp-course
 
 *Changes:*
-• Added team notification system
-• Integrated MCP Tools and Prompts
+- Added team notification system
+- Integrated MCP Tools and Prompts
 
 *Links:*
-• <https://github.com/user/mcp-course/pull/42|View Changes>
-• <https://staging.example.com|Visit Site>
+<https://github.com/user/mcp-course/pull/42|View Changes>
 ```
 
 ## Common Issues
@@ -303,6 +317,8 @@ Claude:
 
 ### Message Formatting
 - [Slack markdown](https://api.slack.com/reference/surfaces/formatting) differs from GitHub markdown
+- **Important**: Use `*text*` for bold (not `**text**`)
+- Include `"mrkdwn": true` in webhook payload for proper formatting
 - Test message formatting manually before automating
 - Handle special characters in commit messages properly ([formatting reference](https://api.slack.com/reference/surfaces/formatting#escaping))
 


### PR DESCRIPTION
## Summary
- Added video screencasts to Unit 3 documentation showing MCP server features in action
- Updated Slack notification format for better readability with rotating_light emoji
- Enhanced webhook implementation to properly support Slack markdown formatting

## Changes
- **Documentation**: Added screencasts to all three Unit 3 modules demonstrating:
  - PR chaos problem and the MCP solution
  - Real-time CI/CD monitoring with GitHub Actions
  - Complete automation system with Slack notifications
- **Code improvements**: 
  - Updated Slack notification template to use cleaner format
  - Added explicit `mrkdwn: true` to Slack webhook payload
- **Housekeeping**: Added videos/ directory to .gitignore

## Note on video hosting
@burtenshaw - The screencasts are currently hosted at https://huggingface.co/datasets/mcp-course/videos but there seems to be an issue with LFS preventing the videos from being playable directly. Could we either:
1. Disable LFS for the videos dataset and its subdirectories so videos can be streamed directly, or
2. Consider hosting the videos elsewhere?

This would ensure the screencasts load correctly in the documentation.