### PR TITLE
fix: markdown rendering in tips and extract constants

### DIFF
--- a/projects/unit3/build-mcp-server/solution/server.py
+++ b/projects/unit3/build-mcp-server/solution/server.py
@@ -7,7 +7,7 @@ A minimal MCP server that provides tools for analyzing file changes and suggesti
 import json
 import os
 import subprocess
-from typing import Dict, List, Any, Optional
+from typing import Optional
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -17,6 +17,34 @@ mcp = FastMCP("pr-agent")
 
 # PR template directory (shared between starter and solution)
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
+
+# Default PR templates
+DEFAULT_TEMPLATES = {
+    "bug.md": "Bug Fix",
+    "feature.md": "Feature",
+    "docs.md": "Documentation",
+    "refactor.md": "Refactor",
+    "test.md": "Test",
+    "performance.md": "Performance",
+    "security.md": "Security"
+}
+
+# Type mapping for PR templates
+TYPE_MAPPING = {
+    "bug": "bug.md",
+    "fix": "bug.md",
+    "feature": "feature.md",
+    "enhancement": "feature.md",
+    "docs": "docs.md",
+    "documentation": "docs.md",
+    "refactor": "refactor.md",
+    "cleanup": "refactor.md",
+    "test": "test.md",
+    "testing": "test.md",
+    "performance": "performance.md",
+    "optimization": "performance.md",
+    "security": "security.md"
+}
 
 
 @mcp.tool()
@@ -44,7 +72,7 @@ async def analyze_file_changes(
                 root = roots_result.roots[0]
                 # FileUrl object has a .path property that gives us the path directly
                 working_directory = root.uri.path
-            except Exception as e:
+            except Exception:
                 # If we can't get roots, fall back to current directory
                 pass
         
@@ -143,30 +171,14 @@ async def analyze_file_changes(
 @mcp.tool()
 async def get_pr_templates() -> str:
     """List available PR templates with their content."""
-    templates = []
-    
-    # Define default templates
-    default_templates = {
-        "bug.md": "Bug Fix",
-        "feature.md": "Feature",
-        "docs.md": "Documentation",
-        "refactor.md": "Refactor",
-        "test.md": "Test",
-        "performance.md": "Performance",
-        "security.md": "Security"
-    }
-    
-    for filename, template_type in default_templates.items():
-        template_path = TEMPLATES_DIR / filename
-        
-        # Read template content
-        content = template_path.read_text()
-        
-        templates.append({
+    templates = [
+        {
             "filename": filename,
             "type": template_type,
-            "content": content
-        })
+            "content": (TEMPLATES_DIR / filename).read_text()
+        }
+        for filename, template_type in DEFAULT_TEMPLATES.items()
+    ]
     
     return json.dumps(templates, indent=2)
 
@@ -184,25 +196,8 @@ async def suggest_template(changes_summary: str, change_type: str) -> str:
     templates_response = await get_pr_templates()
     templates = json.loads(templates_response)
     
-    # Map change types to template files
-    type_mapping = {
-        "bug": "bug.md",
-        "fix": "bug.md",
-        "feature": "feature.md",
-        "enhancement": "feature.md",
-        "docs": "docs.md",
-        "documentation": "docs.md",
-        "refactor": "refactor.md",
-        "cleanup": "refactor.md",
-        "test": "test.md",
-        "testing": "test.md",
-        "performance": "performance.md",
-        "optimization": "performance.md",
-        "security": "security.md"
-    }
-    
     # Find matching template
-    template_file = type_mapping.get(change_type.lower(), "feature.md")
+    template_file = TYPE_MAPPING.get(change_type.lower(), "feature.md")
     selected_template = next(
         (t for t in templates if t["filename"] == template_file),
         templates[0]  # Default to first template if no match

--- a/projects/unit3/slack-notification/solution/server.py
+++ b/projects/unit3/slack-notification/solution/server.py
@@ -8,7 +8,7 @@ import json
 import os
 import subprocess
 import requests
-from typing import Dict, Any, Optional
+from typing import Optional
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -19,8 +19,36 @@ mcp = FastMCP("pr-agent-slack")
 # PR template directory (shared between starter and solution)
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
 
+# Default PR templates
+DEFAULT_TEMPLATES = {
+    "bug.md": "Bug Fix",
+    "feature.md": "Feature",
+    "docs.md": "Documentation",
+    "refactor.md": "Refactor",
+    "test.md": "Test",
+    "performance.md": "Performance",
+    "security.md": "Security"
+}
+
 # File where webhook server stores events
 EVENTS_FILE = Path(__file__).parent / "github_events.json"
+
+# Type mapping for PR templates
+TYPE_MAPPING = {
+    "bug": "bug.md",
+    "fix": "bug.md",
+    "feature": "feature.md",
+    "enhancement": "feature.md",
+    "docs": "docs.md",
+    "documentation": "docs.md",
+    "refactor": "refactor.md",
+    "cleanup": "refactor.md",
+    "test": "test.md",
+    "testing": "test.md",
+    "performance": "performance.md",
+    "optimization": "performance.md",
+    "security": "security.md"
+}
 
 
 # ===== Tools from Modules 1 & 2 (Complete with output limiting) =====
@@ -50,7 +78,7 @@ async def analyze_file_changes(
                 root = roots_result.roots[0]
                 # FileUrl object has a .path property that gives us the path directly
                 working_directory = root.uri.path
-            except Exception as e:
+            except Exception:
                 # If we can't get roots, fall back to current directory
                 pass
         
@@ -123,30 +151,14 @@ async def analyze_file_changes(
 @mcp.tool()
 async def get_pr_templates() -> str:
     """List available PR templates with their content."""
-    templates = []
-    
-    # Define default templates
-    default_templates = {
-        "bug.md": "Bug Fix",
-        "feature.md": "Feature",
-        "docs.md": "Documentation",
-        "refactor.md": "Refactor",
-        "test.md": "Test",
-        "performance.md": "Performance",
-        "security.md": "Security"
-    }
-    
-    for filename, template_type in default_templates.items():
-        template_path = TEMPLATES_DIR / filename
-        
-        # Read template content
-        content = template_path.read_text()
-        
-        templates.append({
+    templates = [
+        {
             "filename": filename,
             "type": template_type,
-            "content": content
-        })
+            "content": (TEMPLATES_DIR / filename).read_text()
+        }
+        for filename, template_type in DEFAULT_TEMPLATES.items()
+    ]
     
     return json.dumps(templates, indent=2)
 
@@ -164,25 +176,8 @@ async def suggest_template(changes_summary: str, change_type: str) -> str:
     templates_response = await get_pr_templates()
     templates = json.loads(templates_response)
     
-    # Map change types to template files
-    type_mapping = {
-        "bug": "bug.md",
-        "fix": "bug.md",
-        "feature": "feature.md",
-        "enhancement": "feature.md",
-        "docs": "docs.md",
-        "documentation": "docs.md",
-        "refactor": "refactor.md",
-        "cleanup": "refactor.md",
-        "test": "test.md",
-        "testing": "test.md",
-        "performance": "performance.md",
-        "optimization": "performance.md",
-        "security": "security.md"
-    }
-    
     # Find matching template
-    template_file = type_mapping.get(change_type.lower(), "feature.md")
+    template_file = TYPE_MAPPING.get(change_type.lower(), "feature.md")
     selected_template = next(
         (t for t in templates if t["filename"] == template_file),
         templates[0]  # Default to first template if no match

--- a/projects/unit3/slack-notification/starter/server.py
+++ b/projects/unit3/slack-notification/starter/server.py
@@ -7,7 +7,7 @@ Combines all MCP primitives (Tools and Prompts) for complete team communication 
 import json
 import os
 import subprocess
-from typing import Dict, Any, Optional
+from typing import Optional
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -18,8 +18,36 @@ mcp = FastMCP("pr-agent-slack")
 # PR template directory (shared between starter and solution)
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
 
+# Default PR templates
+DEFAULT_TEMPLATES = {
+    "bug.md": "Bug Fix",
+    "feature.md": "Feature",
+    "docs.md": "Documentation",
+    "refactor.md": "Refactor",
+    "test.md": "Test",
+    "performance.md": "Performance",
+    "security.md": "Security"
+}
+
 # File where webhook server stores events
 EVENTS_FILE = Path(__file__).parent / "github_events.json"
+
+# Type mapping for PR templates
+TYPE_MAPPING = {
+    "bug": "bug.md",
+    "fix": "bug.md",
+    "feature": "feature.md",
+    "enhancement": "feature.md",
+    "docs": "docs.md",
+    "documentation": "docs.md",
+    "refactor": "refactor.md",
+    "cleanup": "refactor.md",
+    "test": "test.md",
+    "testing": "test.md",
+    "performance": "performance.md",
+    "optimization": "performance.md",
+    "security": "security.md"
+}
 
 
 # ===== Tools from Modules 1 & 2 (Complete with output limiting) =====
@@ -101,30 +129,14 @@ async def analyze_file_changes(
 @mcp.tool()
 async def get_pr_templates() -> str:
     """List available PR templates with their content."""
-    templates = []
-    
-    # Define default templates
-    default_templates = {
-        "bug.md": "Bug Fix",
-        "feature.md": "Feature",
-        "docs.md": "Documentation",
-        "refactor.md": "Refactor",
-        "test.md": "Test",
-        "performance.md": "Performance",
-        "security.md": "Security"
-    }
-    
-    for filename, template_type in default_templates.items():
-        template_path = TEMPLATES_DIR / filename
-        
-        # Read template content
-        content = template_path.read_text()
-        
-        templates.append({
+    templates = [
+        {
             "filename": filename,
             "type": template_type,
-            "content": content
-        })
+            "content": (TEMPLATES_DIR / filename).read_text()
+        }
+        for filename, template_type in DEFAULT_TEMPLATES.items()
+    ]
     
     return json.dumps(templates, indent=2)
 
@@ -142,25 +154,8 @@ async def suggest_template(changes_summary: str, change_type: str) -> str:
     templates_response = await get_pr_templates()
     templates = json.loads(templates_response)
     
-    # Map change types to template files
-    type_mapping = {
-        "bug": "bug.md",
-        "fix": "bug.md",
-        "feature": "feature.md",
-        "enhancement": "feature.md",
-        "docs": "docs.md",
-        "documentation": "docs.md",
-        "refactor": "refactor.md",
-        "cleanup": "refactor.md",
-        "test": "test.md",
-        "testing": "test.md",
-        "performance": "performance.md",
-        "optimization": "performance.md",
-        "security": "security.md"
-    }
-    
     # Find matching template
-    template_file = type_mapping.get(change_type.lower(), "feature.md")
+    template_file = TYPE_MAPPING.get(change_type.lower(), "feature.md")
     selected_template = next(
         (t for t in templates if t["filename"] == template_file),
         templates[0]  # Default to first template if no match

--- a/units/en/unit3/build-mcp-server.mdx
+++ b/units/en/unit3/build-mcp-server.mdx
@@ -178,7 +178,9 @@ Then:
 3. Watch Claude use your tools to provide intelligent suggestions
 
 <Tip warning={true}>
+
 **Common first error**: If you get "MCP tool response exceeds maximum allowed tokens (25000)", this is expected! Large repositories can generate massive diffs. This is a valuable learning moment - see the "Handling Large Outputs" section for the solution.
+
 </Tip>
 
 ## Common Patterns
@@ -212,13 +214,17 @@ except Exception as e:
 ```
 
 <Tip warning={true}>
+
 **Error Handling**: Always return valid JSON from your tools, even for errors. Claude needs structured data to understand what went wrong and provide helpful responses to users.
+
 </Tip>
 
 ### Handling Large Outputs (Critical Learning Moment!)
 
 <Tip warning={true}>
+
 **Real-world constraint**: MCP tools have a token limit of 25,000 tokens per response. Large git diffs can easily exceed this limit 10x or more! This is a critical lesson for production MCP development.
+
 </Tip>
 
 When implementing `analyze_file_changes`, you'll likely encounter this error:

--- a/units/en/unit3/github-actions-integration.mdx
+++ b/units/en/unit3/github-actions-integration.mdx
@@ -147,7 +147,9 @@ The webhook server handles all the HTTP details - you just need to read the JSON
 Just like in Module 1 where you created tools for file analysis, you'll now create tools for CI/CD analysis. These tools will work alongside your existing PR analysis tools, giving Claude a complete view of both code changes and build status.
 
 <Tip>
+
 **Note**: The starter code already includes the output limiting fix from Module 1, so you won't encounter token limit errors. Focus on the new concepts in this module!
+
 </Tip>
 
 Implement two new tools:

--- a/units/en/unit3/introduction.mdx
+++ b/units/en/unit3/introduction.mdx
@@ -71,7 +71,9 @@ Follow the [official installation guide](https://docs.anthropic.com/en/docs/clau
 Once installed, you'll use Claude Code throughout this unit to test your MCP server and interact with the workflow automation you build.
 
 <Tip warning={true}>
+
 **New to Claude Code?** If you encounter any setup issues, the [troubleshooting guide](https://docs.anthropic.com/en/docs/claude-code/troubleshooting) covers common installation and authentication problems.
+
 </Tip>
 
 By the end of this unit, you'll have built a complete MCP server that demonstrates how to transform Claude Code into a powerful team development assistant, with hands-on experience using all three MCP primitives.

--- a/units/en/unit3/slack-notification.mdx
+++ b/units/en/unit3/slack-notification.mdx
@@ -131,7 +131,9 @@ slack-notification/
    - Treat it like a password - anyone with this URL can send messages to your channel
 
 <Tip warning={true}>
+
 **Security Alert**: Webhook URLs are sensitive credentials! Anyone with your webhook URL can send messages to your Slack channel. Always store them as environment variables and never commit them to version control.
+
 </Tip>
 
 ### Step 2: Add Slack Tool (15 min)
@@ -139,7 +141,9 @@ slack-notification/
 Now that you have a working webhook, you'll add a new MCP tool to your existing server.py from Module 2. This tool will handle sending notifications to Slack by making HTTP requests to the webhook URL.
 
 <Tip>
+
 **Note**: The starter code includes all improvements from Modules 1 & 2 (output limiting, webhook handling). Focus on the new Slack integration!
+
 </Tip>
 
 Add this tool to your server.py:


### PR DESCRIPTION
## Summary
- Fix markdown rendering issues in Tip components by adding proper line breaks
- Extract dictionaries as module-level constants for better code organization
- Make code more pythonic with list comprehensions

## Changes

### Markdown Rendering Fixes
- Added missing line breaks after `<Tip>` and `<Tip warning={true}>` tags and before closing `</Tip>` tags
- This ensures markdown content (like **bold text**) renders properly inside tooltips
- Fixed 5 Tip components across 4 MDX files in unit3

### Code Quality Improvements (per @elie's review)
- Extract `type_mapping` as `TYPE_MAPPING` constant ([review comment](https://github.com/huggingface/mcp-course/commit/72703c28e47da307015a00d5d287056803d4ee1f#r158071748))
- Extract `default_templates` as `DEFAULT_TEMPLATES` constant  
- Convert `get_pr_templates` loops to list comprehensions ([review comment](https://github.com/huggingface/mcp-course/commit/72703c28e47da307015a00d5d287056803d4ee1f#r158071738))
- Remove unused imports (`Dict`, `List`, `Any` from typing)
- Fix unused exception variables

### Files Modified
- 5 Python server files (build-mcp-server, github-actions-integration, slack-notification)
- 4 MDX lesson files (introduction, build-mcp-server, github-actions-integration, slack-notification)

## Test plan
- [x] Verify markdown renders correctly in Tip components
- [x] Ensure all Python files run without import errors
- [x] Confirm constants are properly used in all functions