### PR TITLE
Added details for setting up a development environment and running an MCP server locally

### DIFF
--- a/units/en/unit1/sdk.mdx
+++ b/units/en/unit1/sdk.mdx
@@ -53,6 +53,36 @@ if __name__ == "__main__":
 
 Once you have your server implemented, you can start it by running the server script.
 
+Install `uv` (recommended by the MCP ecosystem)
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Add `uv` to your PATH:
+```bash
+source $HOME/.local/bin/env
+```
+
+Verify `uv` is working:
+```bash
+uv --version
+```
+Create a virtual environment:
+```bash
+python -m venv myenv && source myenv/bin/activate
+```
+
+Install MCP:
+```bash
+uv pip install mcp
+```
+
+Install MCP CLI:
+```bash
+uv pip install "mcp[cli]"
+```
+
+Run the server:
 ```bash
 mcp dev server.py
 ```
@@ -161,19 +191,4 @@ MCP is designed to be language-agnostic, and there are official SDKs available f
 
 | Language   | Repository                                                                                               | Maintainer(s)       | Status           |
 | ---------- | -------------------------------------------------------------------------------------------------------- | ------------------- | ---------------- |
-| TypeScript | [github.com/modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) | Anthropic           | Active           |
-| Python     | [github.com/modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk)         | Anthropic           | Active           |
-| Java       | [github.com/modelcontextprotocol/java-sdk](https://github.com/modelcontextprotocol/java-sdk)             | Spring AI (VMware)  | Active           |
-| Kotlin     | [github.com/modelcontextprotocol/kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk)         | JetBrains           | Active           |
-| C#         | [github.com/modelcontextprotocol/csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk)         | Microsoft           | Active (Preview) |
-| Swift      | [github.com/modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)           | loopwork-ai         | Active           |
-| Rust       | [github.com/modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk)             | Anthropic/Community | Active           |
-| Dart       | [https://github.com/leehack/mcp_dart](https://github.com/leehack/mcp_dart)                               | Flutter Community   | Active           |
-
-These SDKs provide language-specific abstractions that simplify working with the MCP protocol, allowing you to focus on implementing the core logic of your servers or clients rather than dealing with low-level protocol details.
-
-## Next Steps
-
-We've only scratched the surface of what you can do with the MCP but you've already got a basic server running. In fact, you've also connected to it using the MCP Client in the browser.
-
-In the next section, we'll look at how to connect to your server from an LLM.
+| TypeScript | [github.com/modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) 


### PR DESCRIPTION
### Description of MCP Server Setup Script Lines

These lines outline the initial steps required to set up a local development environment for an MCP Server script, using `uv` as the package installer, which is recommended by the MCP ecosystem. This setup is crucial before you can begin developing or modifying your MCP server code.

* ```bash
    curl -LsSf https://astral.sh/uv/install.sh | sh
    ```
    **Description:** This command downloads and executes the installation script for `uv`, a fast Python package installer and dependency resolver. `uv` is recommended for its performance and efficiency within the MCP ecosystem, making it a preferred tool for managing project dependencies.

* ```bash
    source $HOME/.local/bin/env
    ```
    **Description:** After `uv` is installed, this command sources a script that adds `uv`'s executable directory (typically `$HOME/.local/bin`) to your system's `PATH` environment variable. This allows you to run `uv` commands directly from any directory in your terminal without specifying the full path to the executable.

* ```bash
    uv --version
    ```
    **Description:** This command verifies that `uv` has been successfully installed and is accessible in your `PATH`. It prints the installed version of `uv`, confirming that you can proceed with using it for package management.

* ```bash
    python -m venv myenv && source myenv/bin/activate
    ```
    **Description:** This line creates a new Python virtual environment named `myenv`. Virtual environments are isolated Python environments that allow you to manage project-specific dependencies without interfering with your system's global Python packages. The `&& source myenv/bin/activate` part then activates this newly created virtual environment, meaning any subsequent Python commands or package installations will apply only within `myenv`.

* ```bash
    uv pip install mcp
    ```
    **Description:** Inside the activated virtual environment, this command uses `uv` to install the core `mcp` library. This is the fundamental package required to run and develop applications within the Multi-Cloud Platform (MCP) framework.

* ```bash
    uv pip install "mcp[cli]"
    ```
    **Description:** This command installs the `mcp` library along with its command-line interface (CLI) dependencies. The `[cli]` extra ensures that all necessary components for interacting with MCP via the command line are available, providing utilities for development, deployment, and management.

* ```bash
    mcp dev server.py
    ```
    **Description:** Finally, this command runs your MCP server script (named `server.py` in this example) in development mode. The `mcp dev` command typically provides features like auto-reloading on code changes, detailed logging, and other developer-friendly functionalities, making it easier to test and debug your MCP server locally before deployment.

---