### PR TITLE
Use uv pip to install gradio

### DIFF
--- a/units/en/unit1/gradio-mcp.mdx
+++ b/units/en/unit1/gradio-mcp.mdx
@@ -25,7 +25,7 @@ Combining Gradio with MCP allows you to create both human-friendly interfaces an
 To use Gradio with MCP support, you'll need to install Gradio with the MCP extra:
 
 ```bash
-pip install "gradio[mcp]"
+uv pip install "gradio[mcp]"
 ```
 
 You'll also need an LLM application that supports tool calling using the MCP protocol, such as Cursor ( known as "MCP Hosts").


### PR DESCRIPTION
`pip install gradio` does install gradio, but using the system python interpreter (e.g., homebrew) and not the venv created earlier in this chapter.

Update the instruction to install gradio using `uv pip install "gradio[mcp]"` so the package is installed in the virtual environment site packages, allowing the interpreter to find it.