### PR TITLE
fix(unit3_1): update import for HfHubHTTPError

### DIFF
--- a/units/en/unit3_1/creating-the-mcp-server.mdx
+++ b/units/en/unit3_1/creating-the-mcp-server.mdx
@@ -33,7 +33,7 @@ import os
 import json
 from fastmcp import FastMCP
 from huggingface_hub import HfApi, model_info, ModelCard, ModelCardData
-from huggingface_hub.utils import HfHubHTTPError
+from huggingface_hub.errors import HfHubHTTPError
 from dotenv import load_dotenv
 
 load_dotenv()


### PR DESCRIPTION
Update import path for HfHubHTTPError

Fix the following error reported by Pylance

"HfHubHTTPError" is not exported from module "huggingface_hub.utils"
  Import from "huggingface_hub.errors" insteadPylancereportPrivateImportUsage