### PR TITLE
Add HF access token permissions setup for tiny agents

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -257,6 +257,21 @@ Then, we will need to log in to the Hugging Face Hub to access the MCP servers. 
 ```bash
 huggingface-cli login
 ```
+### Configure Access Token Permissions
+
+After creating your Hugging Face access token and logging in, you need to ensure your token has the proper permissions to work with inference providers.
+
+**Important:** If you skip this step, you may encounter authentication errors when running tiny agents with hosted models.
+
+1. Go to your [Hugging Face Access Tokens page](https://huggingface.co/settings/tokens)
+2. Find your MCP token and click the three dots (⋮) next to it
+3. Select **"Edit permissions"**
+4. Under the **Inference** section, check the box for:
+   - **"Make calls to Inference Providers"**
+5. Save your changes
+
+This permission is required because tiny agents need to make API calls to hosted models like `Qwen/Qwen2.5-72B-Instruct` through providers like Nebius.
+
 
 <hfoptions id="language">
 <hfoption id="python">


### PR DESCRIPTION
Add a new "Configure Access Token Permissions" section to the Setup instructions for tiny agents. This addresses a common issue where users encounter authentication errors when running tiny agents with hosted models because their Hugging Face access tokens lack the "Make calls to Inference Providers" permission.

Changes:
- Added step-by-step instructions to configure token permissions
- Included clear warning about potential authentication errors
- Explained why this permission is required for inference providers like Nebius
- Positioned after login step for logical setup flow

This change will help new users avoid frustrating authentication issues and get up and running faster with MCP tiny agents.