### PR TITLE
Update ollama run command for devstral small

### DIFF
--- a/units/en/unit2/continue-client.mdx
+++ b/units/en/unit2/continue-client.mdx
@@ -57,7 +57,7 @@ To use Ollama, you can [install](https://ollama.com/download) it and download th
 For example, you can download and run the [Devstral-Small](https://huggingface.co/unsloth/Devstral-Small-2505-GGUF?local-app=ollama) model with:
 
 ```bash
-ollama run unsloth/devstral-small-2505-gguf:Q4_K_M
+ollama run hf.co/unsloth/Devstral-Small-2505-GGUF:Q4_K_M
 ```
 </hfoption>
 </hfoptions>


### PR DESCRIPTION
The command for running unsloth/devstral-small is incorrect
```
➜  ~ ollama run unsloth/devstral-small-2505-gguf:Q4_K_M
pulling manifest
Error: pull model manifest: file does not exist
```

fixed as
```
➜  ~ ollama run hf.co/unsloth/Devstral-Small-2505-GGUF:Q4_K_M
pulling manifest
```