### PR TITLE
Update gradio-client.mdx to use 'transport' key as SSE

### DIFF
--- a/units/en/unit2/gradio-client.mdx
+++ b/units/en/unit2/gradio-client.mdx
@@ -20,7 +20,7 @@ Let's connect to an example MCP Server that is already running on Hugging Face. 
 from smolagents.mcp_client import MCPClient
 
 with MCPClient(
-    {"url": "https://abidlabs-mcp-tool-http.hf.space/gradio_api/mcp/sse"}
+    {"url": "https://abidlabs-mcp-tool-http.hf.space/gradio_api/mcp/sse", "transport": "sse"}
 ) as tools:
     # Tools from the remote server are available
     print("\n".join(f"{t.name}: {t.description}" for t in tools))


### PR DESCRIPTION
```
FutureWarning: Passing a dict as server_parameters without specifying the 'transport' key is deprecated. For now, it defaults to the legacy 'sse' (HTTP+SSE) transport, but this default will change to 'streamable-http' in version 1.20. Please add the 'transport' key explicitly. 
```