### PR TITLE
fix: removed duplicated sentence in Key Concepts section

### DIFF
--- a/units/en/unit1/key-concepts.mdx
+++ b/units/en/unit1/key-concepts.mdx
@@ -31,8 +31,6 @@ MCP transforms this into an M+N problem by providing a standard interface: each 
 
 ![With MCP](https://huggingface.co/datasets/mcp-course/images/resolve/main/unit1/2.png)
 
-Each AI application implements the client side of MCP once, and each tool/data source implements the server side once.
-
 ## Core MCP Terminology
 
 Now that we understand the problem that MCP solves, let's dive into the core terminology and concepts that make up the MCP protocol.


### PR DESCRIPTION
This PR removes a duplicated sentence from `units/en/unit1/key-concepts.mdx`.

The sentence:
> Each AI application implements the client side of MCP once, and each tool/data source implements the server side once.

was listed twice and is now reduced to a single instance for clarity.
