### PR TITLE
Update gradio-server.mdx

### DIFF
--- a/units/en/unit2/gradio-server.mdx
+++ b/units/en/unit2/gradio-server.mdx
@@ -67,7 +67,7 @@ demo = gr.Interface(
 
 # Launch the interface and MCP server
 if __name__ == "__main__":
-    demo.launch(mcp_server=True)
+    demo.launch(mcp_server=True)  //demo.launch()   for gradio version 4.44.1 and above
 ```
 
 ## Understanding the Code


### PR DESCRIPTION
For latest version of gradio, we dont need the command mcp_server=True for launching the app inside the main function.