### PR TITLE
Update tiny-agents example

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -272,10 +272,8 @@ Now, let's create an agent configuration file `agent.json`.
     "servers": [
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"]
-            }
+              "command": "npx",
+              "args": ["@playwright/mcp@latest"]
         }
     ]
 }

--- a/units/en/unit2/tiny-agents.mdx
+++ b/units/en/unit2/tiny-agents.mdx
@@ -76,13 +76,11 @@ The JSON file will look like this:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote",
-					"http://localhost:7860/gradio_api/mcp/sse" // This is the MCP Server we created in the previous section
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote",
+				"http://localhost:7860/gradio_api/mcp/sse" // This is the MCP Server we created in the previous section
+			]
 		}
 	]
 }
@@ -114,13 +112,11 @@ The JSON file will look like this:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote", 
-					"http://localhost:7860/gradio_api/mcp/sse"
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote", 
+				"http://localhost:7860/gradio_api/mcp/sse"
+			]
 		}
 	]
 }
@@ -154,13 +150,11 @@ We could also use an open source model running locally with Tiny Agents. If we s
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote",
-					"http://localhost:1234/v1/mcp/sse"
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote",
+				"http://localhost:1234/v1/mcp/sse"
+			]
 		}
 	]
 }

--- a/units/en/unit3_1/mcp-client.mdx
+++ b/units/en/unit3_1/mcp-client.mdx
@@ -66,12 +66,10 @@ Let's continue with the agent creation:
                 servers=[
                     {
                         "type": "stdio",
-                        "config": {
-                            "command": "python",
-                            "args": ["mcp_server.py"],
-                            "cwd": ".",
-                            "env": {"HF_TOKEN": HF_TOKEN} if HF_TOKEN else {},
-                        },
+                        "command": "python",
+                        "args": ["mcp_server.py"],
+                        "cwd": ".",
+                        "env": {"HF_TOKEN": HF_TOKEN} if HF_TOKEN else {},
                     }
                 ],
             )


### PR DESCRIPTION
Following https://github.com/huggingface/huggingface_hub/issues/3203#issuecomment-3063399728 and related to https://github.com/huggingface/huggingface_hub/pull/3205.


Since release [0.33.2](https://github.com/huggingface/huggingface_hub/releases/tag/v0.33.2) `tiny-agents` config follow VSCode format. We made the change without a proper deprecation warning as it's still experimental and we wanted to harmonize with VSCode as quickly as possible (to avoid future conflicts). This PR updates the examples in the MCP course.

Related PRs:
- https://github.com/huggingface/hub-docs/pull/1816
- https://github.com/huggingface/transformers/pull/39245
- https://github.com/huggingface/huggingface_hub/pull/3205
- https://github.com/huggingface/huggingface.js/pull/1599