### PR TITLE
fixed MCP Client agent.json example

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -315,10 +315,8 @@ Create an agent configuration file at `my-agent/agent.json`:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }


### PR DESCRIPTION
The current agent.json config example doesn't work. I changed it to match https://huggingface.co/datasets/tiny-agents/tiny-agents/blob/main/celinah/web-browser/agent.json and examples from the top of this page. It worked after the update