### PR TITLE
Improve grammar and clarity in lemonade-server.mdx

### DIFF
--- a/units/en/unit2/lemonade-server.mdx
+++ b/units/en/unit2/lemonade-server.mdx
@@ -330,7 +330,7 @@ Now let's provide the asistant with some info to get started.
 » Read the contents of C:\Users\your_username\file-assistant\job_description.md
 ```
 
-You should see the an output similar to the following:
+You should see an output similar to the following:
 
 ```
 <Tool iNtxGmOuXHqZVBWmKnfxsc61xsJbsoAM>read_file {"path":"C:\\Users\\your_username\\file-assistant\\job_description.md","length":23}


### PR DESCRIPTION
Corrected a grammatical error in the lemonade-server.mdx file under unit2. 
Replaced "the an output" with "an output" for clarity and correctness.