### PR TITLE
Fix Tiny Agents setup on Windows and JSON schema errors

### DIFF
--- a/units/en/unit2/tiny-agents.mdx
+++ b/units/en/unit2/tiny-agents.mdx
@@ -65,6 +65,7 @@ Let's setup a project with a basic Tiny Agent.
 ```bash
 mkdir my-agent
 touch my-agent/agent.json
+cd my-agent
 ```
 
 The JSON file will look like this:
@@ -76,13 +77,11 @@ The JSON file will look like this:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote",
-					"http://localhost:7860/gradio_api/mcp/sse" // This is the MCP Server we created in the previous section
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote",
+				"http://localhost:7860/gradio_api/mcp/sse"
+			]
 		}
 	]
 }
@@ -91,7 +90,7 @@ The JSON file will look like this:
 We can then run the agent with the following command:
 
 ```bash
-npx @huggingface/tiny-agents run ./my-agent
+npx @huggingface/tiny-agents run agent.json
 ```
 
 </hfoption>
@@ -114,13 +113,11 @@ The JSON file will look like this:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote", 
-					"http://localhost:7860/gradio_api/mcp/sse"
-				]
-			}
+			"command": "npx.cmd",
+			"args": [
+				"mcp-remote",
+				"http://localhost:7860/gradio_api/mcp/sse"
+			]
 		}
 	]
 }
@@ -154,13 +151,11 @@ We could also use an open source model running locally with Tiny Agents. If we s
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote",
-					"http://localhost:1234/v1/mcp/sse"
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote",
+				"http://localhost:1234/v1/mcp/sse"
+			]
 		}
 	]
 }


### PR DESCRIPTION
Changes:

Remove invalid JSON comment (\\) from agent.json to fix the JSONDecodeError in Python CLI.

Flatten servers schema by moving command and args out of the nested config object, matching the Tiny Agents spec (prevents “Required: command” validation errors in TS).

Windows-compatible command in agent.json: changed "command": "npx" to "command": "npx.cmd" so the Python CLI can spawn the correct executable on Win32.



Result:

Python runner no longer throws [WinError 193] or JSON parsing errors.

TypeScript runner passes schema validation and connects successfully to the live MCP endpoint.