### PR TITLE
Fixing configuration file for agent

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -272,10 +272,8 @@ Now, let's create an agent configuration file `agent.json`.
     "servers": [
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"]
-            }
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
         }
     ]
 }
@@ -315,10 +313,8 @@ Create an agent configuration file at `my-agent/agent.json`:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }


### PR DESCRIPTION
The command and args are wrapped within a config structure which is generates an error when executing tiny-agents