### PR TITLE
Fix KeyError command

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -272,10 +272,8 @@ Now, let's create an agent configuration file `agent.json`.
     "servers": [
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"]
-            }
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
         }
     ]
 }


### PR DESCRIPTION
Fix:
```
tiny-agents run agent.json

An unexpected error occurred: 'command'
Traceback (most recent call last):
  File "/home/vernica/proj/prep/huggingface-mcp/.venv/lib/python3.13/site-packages/huggingface_hub/inference/_mcp/cli.py", line 152, in 
run_agent
    await agent.load_tools()
  File "/home/vernica/proj/prep/huggingface-mcp/.venv/lib/python3.13/site-packages/huggingface_hub/inference/_mcp/agent.py", line 58, in 
load_tools
    await self.add_mcp_server(**cfg)
  File "/home/vernica/proj/prep/huggingface-mcp/.venv/lib/python3.13/site-packages/huggingface_hub/inference/_mcp/mcp_client.py", line 162, 
in add_mcp_server
    logger.info(f"Connecting to stdio MCP server with command: {params['command']} {params.get('args', [])}")
                                                                ~~~~~~^^^^^^^^^^^
KeyError: 'command'


An unexpected error occurred: 'command'
```