### PR TITLE
fix broken agent.json MCP server example

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -311,16 +311,18 @@ Create an agent configuration file at `my-agent/agent.json`:
 ```json
 {
 	"model": "Qwen/Qwen2.5-72B-Instruct",
-	"provider": "nebius",
-	"servers": [
-		{
-			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
-		}
-	]
+    "provider": "nebius",
+    "servers": [
+        {
+            "type": "stdio",
+            "command": "npm",
+            "args": [
+                "exec",
+                "-y",
+                "@playwright/mcp@0.0.33"
+            ]
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
Replaced non-functional snippet using nested config with npx @playwright/mcp@latest (ignored by tiny-agents because command was not at server root) with a working stdio server definition:

{
"type": "stdio",
"command": "npm",
"args": ["exec", "-y", "@playwright/mcp@0.0.33"]
}

Changes:

Flattened server fields (command / args at top level under servers[] item) Pin explicit version @playwright/mcp@0.0.33 for reproducibility Restores server startup and tool discovery during agent initialization