### PR TITLE
Fix KeyError: 'command' in MCP client by supporting nested config structure

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -272,10 +272,8 @@ Now, let's create an agent configuration file `agent.json`.
     "servers": [
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"]
-            }
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
         }
     ]
 }


### PR DESCRIPTION
Fixes #172
