### PR TITLE
fix(agent.json): move server command and args to top level to avoid KeyError

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -272,10 +272,8 @@ Now, let's create an agent configuration file `agent.json`.
     "servers": [
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"]
-            }
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
         }
     ]
 }


### PR DESCRIPTION
The MCP client expected `command` and `args` as top-level fields in each server definition, but our agent.json incorrectly nested them under `config`. This caused a KeyError: 'command' when loading tools.

Updated agent.json so that `command` and `args` are defined alongside `type` instead of inside a `config` block. With this change, tiny-agents can correctly launch the stdio server using `npx @playwright/mcp@latest`.