### PR TITLE
Fixes Tiny Agent Script for Unit 1 for MCP-Clients

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -310,17 +310,15 @@ Create an agent configuration file at `my-agent/agent.json`:
 
 ```json
 {
-	"model": "Qwen/Qwen2.5-72B-Instruct",
-	"provider": "nebius",
-	"servers": [
-		{
-			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
-		}
-	]
+    "model": "Qwen/Qwen2.5-72B-Instruct",
+    "provider": "nebius",
+    "servers": [
+        {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
#148 references an error: An unexpected error occurred: 'command' when running tiny-agents run agent.json

this is caused by the incorrectly supplied `agent.json` from the course materials:

```json
{
    "model": "Qwen/Qwen2.5-72B-Instruct",
    "provider": "nebius",
    "servers": [
        {
            "type": "stdio",
            "config": {
                "command": "npx",
                "args": ["@playwright/mcp@latest"]
            }
        }
    ]
}
```

The corrected version as mentioned by @PhilippWuerfel below works as expected without error. I have included this modification within the repo.

```json
{
    "model": "Qwen/Qwen2.5-72B-Instruct",
    "provider": "nebius",
    "servers": [
        {
            "type": "stdio",
            "command": "npx",
            "args": ["@playwright/mcp@latest"]
        }
    ]
}
```

Hope this helps other users and newbies to tiny-agents.