### PR TITLE
Fix the out-dated tiny-agents config file

### DIFF
--- a/units/en/unit2/tiny-agents.mdx
+++ b/units/en/unit2/tiny-agents.mdx
@@ -76,13 +76,11 @@ The JSON file will look like this:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote",
-					"http://localhost:7860/gradio_api/mcp/sse" // This is the MCP Server we created in the previous section
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote",
+				"http://localhost:7860/gradio_api/mcp/sse" // This is the MCP Server we created in the previous section
+			]
 		}
 	]
 }
@@ -114,13 +112,11 @@ The JSON file will look like this:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote", 
-					"http://localhost:7860/gradio_api/mcp/sse"
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote", 
+				"http://localhost:7860/gradio_api/mcp/sse"
+			]
 		}
 	]
 }
@@ -154,13 +150,11 @@ We could also use an open source model running locally with Tiny Agents. If we s
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": [
-					"mcp-remote",
-					"http://localhost:1234/v1/mcp/sse"
-				]
-			}
+			"command": "npx",
+			"args": [
+				"mcp-remote",
+				"http://localhost:1234/v1/mcp/sse"
+			]
 		}
 	]
 }


### PR DESCRIPTION
The tiny-agent config json file is outdated.

When I run it, I got error message.
`
Invalid configuration file:[
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "servers",
      0,
      "command"
    ],
    "message": "Required"
  }
]
`

This commit fixed the issue following the tiny agent in following link: https://huggingface.co/docs/huggingface.js/en/tiny-agents/README#define-your-own-agent