### PR TITLE
typo & syntax in documentation/hf-mcp-server.mdx

### DIFF
--- a/units/en/unit1/hf-mcp-server.mdx
+++ b/units/en/unit1/hf-mcp-server.mdx
@@ -3,7 +3,7 @@
 The Hugging Face MCP (Model Context Protocol) Server connects your MCP‑compatible AI assistant (for example VS Code, Cursor, Zed, or Claude Desktop) directly to the Hugging Face Hub. Once connected, your assistant can search and explore Hub resources and use community tools, all from within your editor, chat or CLI.
 
 > [!TIP]
-> The main advanatage of the Hugging Face MCP Server is that it provides a built-in tools for the hub as well as community tools based on Gradio Spaces. As we start to build our own MCP servers, we'll see that we can use the Hugging Face MCP Server as a reference for our own MCP servers.
+> The main advantage of the Hugging Face MCP Server is that it provides built-in tools for the hub as well as community tools based on Gradio Spaces. As we start to build our own MCP servers, we'll see that we can use the Hugging Face MCP Server as a reference for our own MCP servers.
 
 ## What you can do
 


### PR DESCRIPTION
Hello!

**small summary for the PR**

type = documentation

- Why this change?
I'm proposing the following small changes in the documentation to fix a typo in the word advantage, and eliminating the letter a before built-in tools as it indicates many. Not a single tool.