### PR TITLE
Update og in command for "MCP Clients" subsection from section 1

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -262,7 +262,7 @@ pip install "huggingface_hub[mcp]>=0.32.0"
 Then, we will need to log in to the Hugging Face Hub to access the MCP servers. You can do this with the `huggingface-cli` command line tool. You will need a [login token](https://huggingface.co/docs/huggingface_hub/v0.32.3/en/quick-start#authentication) to do this.
 
 ```bash
-huggingface-cli login
+hf auth login
 ```
 ### Configure Access Token Permissions
 


### PR DESCRIPTION
This PR should fix the issue with the error "huggingface-cli not defined" when trying to login after running 'pip install "huggingface_hub[mcp]>=0.32.0"'

I think the API might have changed and this section remained behind. This new call matches the one from [the official docs](https://huggingface.co/docs/huggingface_hub/en/guides/cli#hf-auth-login)