### PR TITLE
fix: Change provider from 'nebius' to 'together'

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -334,7 +334,7 @@ Create an agent configuration file at `my-agent/agent.json`:
 ```json
 {
     "model": "Qwen/Qwen2.5-72B-Instruct",
-    "provider": "nebius",
+    "provider": "together",
     "servers": [
         {
             "type": "stdio",


### PR DESCRIPTION
I faced issues while running `npx @huggingface/tiny-agents run ./my-agent` with javascript code.
[https://huggingface.co/inference/models/...](https://huggingface.co/inference/models?model=Qwen%2FQwen3-Coder-30B-A3B-Instruct&search=Qwen2.5-72B) is not supporting `nebius`.

<img width="1532" height="369" alt="Screenshot 2025-11-04 at 16 11 37" src="https://github.com/user-attachments/assets/b4f7e80b-1b31-40ff-9059-ff3e3a4cf099" />


This PR resolves the error:

```
@huggingface/tiny-agents/dist/cli.js:115
    throw err;
    ^

InferenceClientInputError: We have not been able to find inference provider information for model Qwen/Qwen2.5-72B-Instruct.
    at makeRequestOptions 
...
```

The configuration currently uses "provider": "nebius", but Qwen2.5-72B-Instruct is NOT available on Nebius.