### PR TITLE
Update outdated model use on the client demostration

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -333,7 +333,7 @@ Create an agent configuration file at `my-agent/agent.json`:
 
 ```json
 {
-    "model": "Qwen/Qwen2.5-72B-Instruct",
+    "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
     "provider": "nebius",
     "servers": [
         {


### PR DESCRIPTION
`Qwen/Qwen2.5-72B-Instruct` is not available anymore and raises a `huggingface_hub.errors.BadRequestError`. Replace it with a current available model.