### PR TITLE
Update inference provider from Nebius to Novita in docs and translations

### DIFF
--- a/units/en/unit1/mcp-clients.mdx
+++ b/units/en/unit1/mcp-clients.mdx
@@ -284,7 +284,7 @@ After creating your Hugging Face access token and logging in, you need to ensure
    - **"Make calls to Inference Providers"**
 5. Save your changes
 
-This permission is required because tiny agents need to make API calls to hosted models like `Qwen/Qwen2.5-72B-Instruct` through providers like Nebius.
+This permission is required because tiny agents need to make API calls to hosted models like `Qwen/Qwen2.5-72B-Instruct` through providers like Novita.
 
 
 <hfoptions id="language">
@@ -299,7 +299,7 @@ Now, let's create an agent configuration file `agent.json`.
     "name": "playwright-agent",
     "description": "Agent with Playwright MCP server",
     "model": "Qwen/Qwen2.5-72B-Instruct",
-    "provider": "nebius",
+    "provider": "novita",
     "servers": [
         {
             "type": "stdio",
@@ -340,7 +340,7 @@ Create an agent configuration file at `my-agent/agent.json`:
 ```json
 {
     "model": "Qwen/Qwen2.5-72B-Instruct",
-    "provider": "nebius",
+    "provider": "novita",
     "servers": [
         {
             "type": "stdio",
@@ -362,7 +362,7 @@ npx @huggingface/tiny-agents run ./my-agent
 
 In the video below, we run the agent and ask it to open a new tab in the browser.
 
-The following example shows a web-browsing agent configured to use the [Qwen/Qwen2.5-72B-Instruct](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct) model via Nebius inference provider, and it comes equipped with a playwright MCP server, which lets it use a web browser! The agent config is loaded specifying [its path in the `tiny-agents/tiny-agents`](https://huggingface.co/datasets/tiny-agents/tiny-agents/tree/main/celinah/web-browser) Hugging Face dataset.
+The following example shows a web-browsing agent configured to use the [Qwen/Qwen2.5-72B-Instruct](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct) model via Novita inference provider, and it comes equipped with a playwright MCP server, which lets it use a web browser! The agent config is loaded specifying [its path in the `tiny-agents/tiny-agents`](https://huggingface.co/datasets/tiny-agents/tiny-agents/tree/main/celinah/web-browser) Hugging Face dataset.
 
 <video controls autoplay loop>
   <source src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/blog/python-tiny-agents/web_browser_agent.mp4" type="video/mp4">

--- a/units/en/unit2/tiny-agents.mdx
+++ b/units/en/unit2/tiny-agents.mdx
@@ -70,7 +70,7 @@ The JSON file will look like this:
 ```json
 {
 	"model": "Qwen/Qwen2.5-72B-Instruct",
-	"provider": "nebius",
+    "provider": "novita",
 	"servers": [
 		{
 			"type": "stdio",
@@ -106,7 +106,7 @@ The JSON file will look like this:
 ```json
 {
 	"model": "Qwen/Qwen2.5-72B-Instruct",
-	"provider": "nebius",
+    "provider": "novita",
 	"servers": [
 		{
 			"type": "stdio",
@@ -173,7 +173,7 @@ To connect our Tiny Agent to the Gradio sentiment analysis server we built earli
 
 ```ts
 const agent = new Agent({
-    provider: process.env.PROVIDER ?? "nebius",
+    provider: process.env.PROVIDER ?? "novita",
     model: process.env.MODEL_ID ?? "Qwen/Qwen2.5-72B-Instruct",
     apiKey: process.env.HF_TOKEN,
     servers: [
@@ -199,7 +199,7 @@ from huggingface_hub import Agent
 
 agent = Agent(
     model="Qwen/Qwen2.5-72B-Instruct",
-    provider="nebius",
+    provider="novita",
     servers=[
         {
             "command": "npx",

--- a/units/vi/unit2/tiny-agents.mdx
+++ b/units/vi/unit2/tiny-agents.mdx
@@ -60,13 +60,13 @@ Với công cụ phân tích cảm xúc Gradio đã kết nối, chúng ta có t
 
 Về cặp mô hình/nhà cung cấp, Agent mẫu của chúng ta mặc định dùng:
 - ["Qwen/Qwen2.5-72B-Instruct"](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct)
-- chạy trên [Nebius](https://huggingface.co/docs/inference-providers/providers/nebius)
+- chạy trên [Novita](https://huggingface.co/docs/inference-providers/providers/novita)
 
 Tất cả cài đặt này đều có thể tùy chỉnh qua biến môi trường! Ở đây, chúng ta cũng sẽ hướng dẫn cách thêm máy chủ Gradio MCP của mình:
 
 ```ts
 const agent = new Agent({
-	provider: process.env.PROVIDER ?? "nebius",
+	provider: process.env.PROVIDER ?? "novita",
 	model: process.env.MODEL_ID ?? "Qwen/Qwen2.5-72B-Instruct",
 	apiKey: process.env.HF_TOKEN,
 	servers: [
@@ -418,7 +418,7 @@ Giờ thì chúng ta đã hiểu về cả Tiny Agents và Gradio MCP servers, h
 
 ```ts
 const agent = new Agent({
-    provider: process.env.PROVIDER ?? "nebius",
+	provider: process.env.PROVIDER ?? "novita",
     model: process.env.MODEL_ID ?? "Qwen/Qwen2.5-72B-Instruct",
     apiKey: process.env.HF_TOKEN,
     servers: [

--- a/units/vi/unit2/tiny-agents.mdx
+++ b/units/vi/unit2/tiny-agents.mdx
@@ -418,7 +418,7 @@ Giờ thì chúng ta đã hiểu về cả Tiny Agents và Gradio MCP servers, h
 
 ```ts
 const agent = new Agent({
-	provider: process.env.PROVIDER ?? "novita",
+    provider: process.env.PROVIDER ?? "novita",
     model: process.env.MODEL_ID ?? "Qwen/Qwen2.5-72B-Instruct",
     apiKey: process.env.HF_TOKEN,
     servers: [


### PR DESCRIPTION
## Summary
- Change provider name from `nebius` to `novita`.
- Apply the provider update in English and translated docs.

## Why
If you set the provider value to `nebius`, you will see an error because the inference provider has changed to `novita` and `featherless-ai`.

Error message:
```text
Model Qwen/Qwen2.5-72B-Instruct is not supported by provider nebius.
ValueError: Model Qwen/Qwen2.5-72B-Instruct is not supported by provider nebius.
```

## Reference
For more information: https://huggingface.co/Qwen/Qwen2.5-72B-Instruct?inference_provider=novita&language=python&client=openai&inference_api=true